### PR TITLE
fix: 위젯 삭제 버튼 클릭 버그

### DIFF
--- a/src/components/widgets/Widget.tsx
+++ b/src/components/widgets/Widget.tsx
@@ -40,7 +40,7 @@ export const BaseWidget = ({ layout, widget }: Props) => {
         return <div>{widget.name}</div> //추후 위젯 추가
     }
   }
-  const deleteWidget = (event: any) => {
+  const deleteWidget = () => {
     console.log(widget)
   }
 

--- a/src/components/widgets/Widget.tsx
+++ b/src/components/widgets/Widget.tsx
@@ -40,13 +40,15 @@ export const BaseWidget = ({ layout, widget }: Props) => {
         return <div>{widget.name}</div> //추후 위젯 추가
     }
   }
-  const deleteWidget = () => {
+  const deleteWidget = (event: any) => {
     console.log(widget)
   }
 
   return (
-    <div ref={setNodeRef} style={style} {...attributes} {...listeners}>
-      {selectWidget()}
+    <div ref={setNodeRef} style={style} {...attributes}>
+      <div {...listeners} style={{ height: '100%' }}>
+        {selectWidget()}
+      </div>
       {storeVisible ? (
         <Image src={remove} style={removeButtonStyle} onClick={deleteWidget} />
       ) : null}


### PR DESCRIPTION
- resolves #26 

## 개요
원래는 리스너가 부착된 div 엘리먼트의 하위인 삭제버튼에서 onClick을 다루는 식이었는데,
위젯 부분에 리스너를 달고, 삭제 버튼과 형제관계로 만들어서 해결했습니다
아래 같은 느낌입니다
```
기존
{
	<div {listners}>
		<widget/>
		<button {onClick}/>
	<div/>
}

변경
{
	<div>
		<widget {listners}/>
		<button {onClick}/>
	<div/>
}
```

원인은 리액트가 이벤트를 처리하는 방식, 이벤트 버블링/캡처링이 처리되는 방식과 관련된 것으로 추측합니다
정확한 이유는 지금 찾고 있지만, 시간이 좀 더 걸릴 것 같고 일단 문제는 해결했으니 pr 먼저 올리겠습니다

삽질 기록, 정리는 노션 페이지에 있습니다
https://usanglee.notion.site/a46c4335f0db43d1bf30389a72dbf1f0