### PR TITLE
chore: `object-shorthand`, `no-unused-vars` 타입 추가

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -27,9 +27,15 @@ plugins:
   - unused-imports
 
 rules:
+  object-shorthand:
+    - error
+    - always
   curly:
     - error
     - all
+  "@typescript-eslint/no-unused-vars":
+    - error
+    - argsIgnorePattern: "^_"
 
   # prettier
   indent: off


### PR DESCRIPTION
## 개요

- `object-shorthand`: 객체에서 축약 표현 사용을 강제
- `no-unused-vars`: 사용하지 않는 변수를 `_`로 표시하는 것을 허용

