### PR TITLE
fix: 이동버그수정

### DIFF
--- a/src/components/users/Grid.test.tsx
+++ b/src/components/users/Grid.test.tsx
@@ -1,8 +1,8 @@
 import { test, expect, describe } from 'vitest'
-import { Widget } from 'common'
+import { Widget, Widgets } from 'common'
 import { isMovableToEmpty, moveItemSwap } from './GridTools'
 import { widgetsBetween, widgetCoords, coordsOf } from './GridTools'
-import { mock } from 'dummy'
+import { mock, mock1, mock2, mock3, mock4, mock5, mock6 } from 'dummy'
 import { Pos, pos, Size, size } from 'vec2'
 
 type Params = {
@@ -50,28 +50,28 @@ describe('widgetCoords', () => {
 
 test.each`
   pos          | res
-  ${pos(1, 1)} | ${mock[4]}
-  ${pos(1, 0)} | ${undefined}
-  ${pos(0, 1)} | ${undefined}
-  ${pos(2, 2)} | ${undefined}
+  ${pos(1, 1)} | ${mock1}
+  ${pos(1, 0)} | ${null}
+  ${pos(0, 1)} | ${null}
+  ${pos(2, 2)} | ${null}
 `(
   'moveItemSwap(mock[0], $pos, mock) -> [$res]',
-  ({ pos, res }: Params & { res?: Widget }) =>
+  ({ pos, res }: Params & { res?: Widgets }) =>
     expect(moveItemSwap(mock[0], pos, mock)).toEqual(res)
 )
 
 test.each`
   widget     | pos           | res
-  ${mock[0]} | ${pos(1, 1)}  | ${false}
-  ${mock[0]} | ${pos(1, 0)}  | ${false}
-  ${mock[0]} | ${pos(0, 1)}  | ${false}
-  ${mock[0]} | ${pos(2, 2)}  | ${true}
-  ${mock[1]} | ${pos(1, 0)}  | ${true}
-  ${mock[2]} | ${pos(2, 0)}  | ${true}
-  ${mock[3]} | ${pos(0, -1)} | ${true}
-  ${mock[4]} | ${pos(1, 0)}  | ${true}
+  ${mock[0]} | ${pos(1, 1)}  | ${null}
+  ${mock[0]} | ${pos(1, 0)}  | ${null}
+  ${mock[0]} | ${pos(0, 1)}  | ${null}
+  ${mock[0]} | ${pos(2, 2)}  | ${mock2}
+  ${mock[1]} | ${pos(1, 0)}  | ${mock3}
+  ${mock[2]} | ${pos(2, 0)}  | ${mock4}
+  ${mock[3]} | ${pos(0, -1)} | ${mock5}
+  ${mock[4]} | ${pos(1, 0)}  | ${mock6}
 `(
   'isMovableToEmpty($widget, $pos, mock) -> [$res]',
-  ({ widget, pos, res }: Params & { res: boolean }) =>
+  ({ widget, pos, res }: Params & { res: Widgets }) =>
     expect(isMovableToEmpty(widget, pos, mock)).toEqual(res)
 )

--- a/src/components/users/Grid.test.tsx
+++ b/src/components/users/Grid.test.tsx
@@ -51,9 +51,9 @@ describe('widgetCoords', () => {
 test.each`
   pos          | res
   ${pos(1, 1)} | ${mock1}
-  ${pos(1, 0)} | ${null}
-  ${pos(0, 1)} | ${null}
-  ${pos(2, 2)} | ${null}
+  ${pos(1, 0)} | ${undefined}
+  ${pos(0, 1)} | ${undefined}
+  ${pos(2, 2)} | ${undefined}
 `(
   'swapWidget(mock[0], $pos, mock) -> [$res]',
   ({ pos, res }: Params & { res?: Widgets }) =>
@@ -62,9 +62,9 @@ test.each`
 
 test.each`
   widget     | pos           | res
-  ${mock[0]} | ${pos(1, 1)}  | ${null}
-  ${mock[0]} | ${pos(1, 0)}  | ${null}
-  ${mock[0]} | ${pos(0, 1)}  | ${null}
+  ${mock[0]} | ${pos(1, 1)}  | ${undefined}
+  ${mock[0]} | ${pos(1, 0)}  | ${undefined}
+  ${mock[0]} | ${pos(0, 1)}  | ${undefined}
   ${mock[0]} | ${pos(2, 2)}  | ${mock2}
   ${mock[1]} | ${pos(1, 0)}  | ${mock3}
   ${mock[2]} | ${pos(2, 0)}  | ${mock4}

--- a/src/components/users/Grid.test.tsx
+++ b/src/components/users/Grid.test.tsx
@@ -1,6 +1,6 @@
 import { test, expect, describe } from 'vitest'
 import { Widget, Widgets } from 'common'
-import { isMovableToEmpty, moveItemSwap } from './GridTools'
+import { moveEmptyWidget, swapWidget } from './GridTools'
 import { widgetsBetween, widgetCoords, coordsOf } from './GridTools'
 import { mock, mock1, mock2, mock3, mock4, mock5, mock6 } from 'dummy'
 import { Pos, pos, Size, size } from 'vec2'
@@ -55,9 +55,9 @@ test.each`
   ${pos(0, 1)} | ${null}
   ${pos(2, 2)} | ${null}
 `(
-  'moveItemSwap(mock[0], $pos, mock) -> [$res]',
+  'swapWidget(mock[0], $pos, mock) -> [$res]',
   ({ pos, res }: Params & { res?: Widgets }) =>
-    expect(moveItemSwap(mock[0], pos, mock)).toEqual(res)
+    expect(swapWidget(mock[0], pos, mock)).toEqual(res)
 )
 
 test.each`
@@ -71,7 +71,7 @@ test.each`
   ${mock[3]} | ${pos(0, -1)} | ${mock5}
   ${mock[4]} | ${pos(1, 0)}  | ${mock6}
 `(
-  'isMovableToEmpty($widget, $pos, mock) -> [$res]',
+  'moveEmptyWidget($widget, $pos, mock) -> [$res]',
   ({ widget, pos, res }: Params & { res: Widgets }) =>
-    expect(isMovableToEmpty(widget, pos, mock)).toEqual(res)
+    expect(moveEmptyWidget(widget, pos, mock)).toEqual(res)
 )

--- a/src/components/users/Grid.tsx
+++ b/src/components/users/Grid.tsx
@@ -96,22 +96,21 @@ export const Grid = ({ widgets }: { widgets: Widgets }) => {
   const moveItem = (index: number) => {
     const toMove = plus(widgets[index].pos, cursor)
     //빈 공간일 경우
-    if (isMovableToEmpty(widgets[index], cursor, widgets) !== false) {
-      widgets[index].pos = toMove
+    const movable = isMovableToEmpty(widgets[index], cursor, widgets)
+    if (movable) {
+      widgets = movable
       return
     }
     //push할 수 있는 경우
-    if (isPushable(widgets[index], cursor, widgets)) {
-      widgets[index].pos = toMove
+    const pushable = isPushable(widgets[index], cursor, widgets)
+    if (pushable) {
+      widgets = pushable
       return
     }
     //swap할 수 있는 경우
     const swapWidget = moveItemSwap(widgets[index], cursor, widgets)
     if (swapWidget) {
-      const swapCoords = swapWidget.pos
-      swapWidget.pos = widgets[index].pos
-      widgets[index].pos = swapCoords
-      return
+      widgets = swapWidget
     }
     console.log('이동불가') //불가능
   }

--- a/src/components/users/Grid.tsx
+++ b/src/components/users/Grid.tsx
@@ -1,7 +1,6 @@
 import { DndContext, DragEndEvent, DragMoveEvent } from '@dnd-kit/core'
 import { rectSwappingStrategy, SortableContext } from '@dnd-kit/sortable'
 import { BaseWidget } from 'components/widgets/Widget'
-import { Widgets } from 'common'
 import { createRef, DragEvent, LegacyRef, useState } from 'react'
 import {
   gridSize,
@@ -10,10 +9,11 @@ import {
   moveItemSwap,
   widgetsBetween,
 } from './GridTools'
-import { div, mul, neq, plus, pos, round, size, sub } from 'vec2'
+import { div, mul, neq, pos, round, size, sub } from 'vec2'
 import { pipe } from '@mobily/ts-belt'
 import { useAtomValue } from 'jotai'
 import { cursorInWidgetAtom } from 'Atoms'
+import { layoutDummy } from 'dummy'
 
 const tmpStyle: React.CSSProperties = {
   background: '#aaffaa',
@@ -24,7 +24,8 @@ const tmpStyle: React.CSSProperties = {
   gridGap: 10,
 }
 
-export const Grid = ({ widgets }: { widgets: Widgets }) => {
+export const Grid = () => {
+  const [widgets, setWidgets] = useState(layoutDummy)
   const [cursor, setCursor] = useState(pos(0, 0))
   const gridRef: LegacyRef<HTMLDivElement> = createRef()
   const cursorInWidget = useAtomValue(cursorInWidgetAtom)
@@ -68,7 +69,6 @@ export const Grid = ({ widgets }: { widgets: Widgets }) => {
       //prettier-ignore
       if ( widgetsBetween(widgets, correctedCursor, size(1, 1)).length === 0)
       {//나중에 Widget 타입도 생성자 함수 같은 걸 만드는 게 좋을 것 같다
-        console.log('x좌표', correctedCursor.x, 'y좌표', correctedCursor.y)
         return {
           uuid: "저장된 uuid",
           name: cursorInWidget.name,
@@ -78,7 +78,6 @@ export const Grid = ({ widgets }: { widgets: Widgets }) => {
           h: 1,
           data: {}
         }
-        
       }
     }
     return null
@@ -94,23 +93,23 @@ export const Grid = ({ widgets }: { widgets: Widgets }) => {
 
   /** 이동 알고리즘 들어가는 함수 [주기능]*/
   const moveItem = (index: number) => {
-    const toMove = plus(widgets[index].pos, cursor)
     //빈 공간일 경우
     const movable = isMovableToEmpty(widgets[index], cursor, widgets)
     if (movable) {
-      widgets = movable
+      setWidgets(movable)
       return
     }
     //push할 수 있는 경우
     const pushable = isPushable(widgets[index], cursor, widgets)
     if (pushable) {
-      widgets = pushable
+      setWidgets(pushable)
       return
     }
     //swap할 수 있는 경우
     const swapWidget = moveItemSwap(widgets[index], cursor, widgets)
     if (swapWidget) {
-      widgets = swapWidget
+      setWidgets(swapWidget)
+      return
     }
     console.log('이동불가') //불가능
   }

--- a/src/components/users/Grid.tsx
+++ b/src/components/users/Grid.tsx
@@ -4,9 +4,9 @@ import { BaseWidget } from 'components/widgets/Widget'
 import { createRef, DragEvent, LegacyRef, useState } from 'react'
 import {
   gridSize,
-  isPushable,
-  isMovableToEmpty,
-  moveItemSwap,
+  pushWidget,
+  moveEmptyWidget,
+  swapWidget,
   widgetsBetween,
 } from './GridTools'
 import { div, mul, neq, pos, round, size, sub } from 'vec2'
@@ -94,19 +94,19 @@ export const Grid = () => {
   /** 이동 알고리즘 들어가는 함수 [주기능]*/
   const moveItem = (index: number) => {
     //빈 공간일 경우
-    const movable = isMovableToEmpty(widgets[index], cursor, widgets)
+    const movable = moveEmptyWidget(widgets[index], cursor, widgets)
     if (movable) {
       setWidgets(movable)
       return
     }
     //push할 수 있는 경우
-    const pushable = isPushable(widgets[index], cursor, widgets)
+    const pushable = pushWidget(widgets[index], cursor, widgets)
     if (pushable) {
       setWidgets(pushable)
       return
     }
     //swap할 수 있는 경우
-    const swapWidget = moveItemSwap(widgets[index], cursor, widgets)
+    const swapWidget = swapWidget(widgets[index], cursor, widgets)
     if (swapWidget) {
       setWidgets(swapWidget)
       return

--- a/src/components/users/Grid.tsx
+++ b/src/components/users/Grid.tsx
@@ -80,7 +80,7 @@ export const Grid = () => {
         }
       }
     }
-    return null
+    return undefined
   }
   /**
    * dragOver이벤트를 취소하지 않으면 onDrop이벤트가 동작하지 않음

--- a/src/components/users/Grid.tsx
+++ b/src/components/users/Grid.tsx
@@ -6,7 +6,6 @@ import {
   gridSize,
   pushWidget,
   moveEmptyWidget,
-  swapWidget,
   widgetsBetween,
 } from './GridTools'
 import { div, mul, neq, pos, round, size, sub } from 'vec2'

--- a/src/components/users/GridTools.ts
+++ b/src/components/users/GridTools.ts
@@ -70,7 +70,7 @@ const isInGridSize = (widget: Widget) => {
 }
 
 /** 위젯을 밀 수 있는 지 확인하는 함수 [주기능]*/
-export const isPushable = (widget: Widget, cursor: Pos, widgets: Widgets) => {
+export const pushWidget = (widget: Widget, cursor: Pos, widgets: Widgets) => {
   const copyWidgets: Widgets = JSON.parse(JSON.stringify(widgets))
   const copyWidget = copyWidgets.find(ele => ele.uuid === widget.uuid)
   if (!copyWidget) {
@@ -91,26 +91,26 @@ export const isPushable = (widget: Widget, cursor: Pos, widgets: Widgets) => {
     .filter(ele => ele.uuid !== copyWidget.uuid)
     .forEach(ele => {
       if (ele.pos.x < movedRangeMiddleX) {
-        if (isPushableTo(ele, pos(-1, 0), copyWidgets)) {
+        if (pushWidgetTo(ele, pos(-1, 0), copyWidgets)) {
           return (ele.pos = plus(ele.pos, pos(-1, 0)))
-        } else if (isPushableTo(ele, pos(1, 0), copyWidgets)) {
+        } else if (pushWidgetTo(ele, pos(1, 0), copyWidgets)) {
           return (ele.pos = plus(ele.pos, pos(1, 0)))
         }
       } else {
-        if (isPushableTo(ele, pos(1, 0), copyWidgets)) {
+        if (pushWidgetTo(ele, pos(1, 0), copyWidgets)) {
           return (ele.pos = plus(ele.pos, pos(1, 0)))
-        } else if (isPushableTo(ele, pos(-1, 0), copyWidgets)) {
+        } else if (pushWidgetTo(ele, pos(-1, 0), copyWidgets)) {
           return (ele.pos = plus(ele.pos, pos(-1, 0)))
         }
       }
     })
-  return isMovableToEmpty(copyWidget, cursor, copyWidgets)
+  return moveEmptyWidget(copyWidget, cursor, copyWidgets)
 }
 
 /**
  * widget를 vec2 방향으로 이동할 수 있는지 확인하기
  */
-const isPushableTo = (widget: Widget, direction: Vec2, widgets: Widgets) => {
+const pushWidgetTo = (widget: Widget, direction: Vec2, widgets: Widgets) => {
   const copyWidgets: Widgets = JSON.parse(JSON.stringify(widgets))
   const copyWidget = copyWidgets.find(ele => ele.uuid === widget.uuid)
   if (!copyWidget) {
@@ -142,11 +142,7 @@ const isPushableTo = (widget: Widget, direction: Vec2, widgets: Widgets) => {
 }
 
 /** 위젯을 교환할 수 있는지 여부를 확인해 교환할 위젯 또는 false를 반환. [완료][주기능]*/
-export const moveItemSwap = (
-  widget: Widget,
-  cursor: Vec2,
-  widgets: Widgets
-) => {
+export const swapWidget = (widget: Widget, cursor: Vec2, widgets: Widgets) => {
   //1. cursor를 통해 교환할 위젯을 찾는다. 이동하려는 좌표에 위치하고, w h 크기가 같아야 함.
   //2. 조건이 맞으면 교환할 위젯을 반환, 실패하면 false
   const copyWidgets: Widgets = JSON.parse(JSON.stringify(widgets))
@@ -175,7 +171,7 @@ export const moveItemSwap = (
   return null
 }
 /** 빈 곳으로 위젯을 이동할 지 여부를 반환한다 [완료] [주기능]*/
-export const isMovableToEmpty = (
+export const moveEmptyWidget = (
   widget: Widget,
   cursor: Vec2,
   widgets: Widgets

--- a/src/components/users/GridTools.ts
+++ b/src/components/users/GridTools.ts
@@ -70,14 +70,10 @@ const isInGridSize = (widget: Widget) => {
 }
 
 /** 위젯을 밀 수 있는 지 확인하는 함수 [주기능]*/
-export const isPushable = (
-  widget: Widget,
-  cursorPosition: Pos,
-  widgets: Widgets
-) => {
+export const isPushable = (widget: Widget, cursor: Pos, widgets: Widgets) => {
   const widgetCopy: Widgets = Array.from(widgets) // 위젯들 밀면서 확인할 widgets의 사본
-  const movedRange = makeMoveCoordinates(widget, cursorPosition) //widget을 cursorPosition만큼 옮길 시 차지하는 좌표범위
-  const movedPos = plus(widget.pos, cursorPosition) //widget을 cursorPosition만큼 옮길 시의 좌표
+  const movedRange = makeMoveCoordinates(widget, cursor) //widget을 cursor만큼 옮길 시 차지하는 좌표범위
+  const movedPos = plus(widget.pos, cursor) //widget을 cursor만큼 옮길 시의 좌표
   const movedRangeWidgets = widgetsBetween(widgets, movedPos, widget.size)
   const xList = movedRange.map(ele => ele.x)
   const movedRangeMiddleX = (Math.max(...xList) + Math.min(...xList)) / 2
@@ -100,7 +96,7 @@ export const isPushable = (
       }
     })
 
-  return isMovableToEmpty(widget, cursorPosition, widgetCopy)
+  return isMovableToEmpty(widget, cursor, widgetCopy)
 }
 
 /**
@@ -108,14 +104,12 @@ export const isPushable = (
  */
 const isPushableTo = (widget: Widget, direction: Vec2, widgets: Widgets) => {
   const movedWidget = move(widget, direction)
-
   // coordinateRangeWidgets로 옮길 곳에 어떤 위젯들이 차지하고 있는지 확인하고
   const movedRange = widgetsBetween(widgets, movedWidget.pos, widget.size)
 
   if (!isInGridSize(movedWidget)) {
     return false
   }
-
   if (movedRange.length === 0) {
     // 만약 그 리스트가 비어있으면 빈 배열이라는 거니까 true
     return true
@@ -123,42 +117,49 @@ const isPushableTo = (widget: Widget, direction: Vec2, widgets: Widgets) => {
     movedRange.length === 1 &&
     movedRange[0].uuid === widget.uuid &&
     isInGridSize(movedRange[0]) // 리스트에 widget만 있으면 어차피 자기 자신이니 true
-  ) {
+  )
     return true
-  }
-
   return false
 }
 
 /** 위젯을 교환할 수 있는지 여부를 확인해 교환할 위젯 또는 false를 반환. [완료][주기능]*/
 export const moveItemSwap = (
   widget: Widget,
-  cursorPosition: Vec2,
+  cursor: Vec2,
   widgets: Widgets
 ) => {
-  //1. cursorPosition를 통해 교환할 위젯을 찾는다. 이동하려는 좌표에 위치하고, w h 크기가 같아야 함.
+  //1. cursor를 통해 교환할 위젯을 찾는다. 이동하려는 좌표에 위치하고, w h 크기가 같아야 함.
   //2. 조건이 맞으면 교환할 위젯을 반환, 실패하면 false
-  const movedPos = plus(widget.pos, cursorPosition)
+  const movedPos = plus(widget.pos, cursor)
   const swapRange = widgetsBetween(widgets, movedPos, widget.size).filter(
     ele => ele.uuid !== widget.uuid
   )
   if (swapRange.length === 1 && pipe(swapRange[0].size, eq(widget.size))) {
-    return widgets.find(ele => ele.uuid === swapRange[0].uuid)
+    const swapWidget = widgets.find(ele => ele.uuid === swapRange[0].uuid)
+    if (swapWidget) {
+      const swapCoords = swapWidget.pos
+      swapWidget.pos = widget.pos
+      widget.pos = swapCoords
+      return widgets
+    } else return null
   }
-  return undefined
+  return null
 }
 /** 빈 곳으로 위젯을 이동할 지 여부를 반환한다 [완료] [주기능]*/
 export const isMovableToEmpty = (
   widget: Widget,
-  cursorPosition: Vec2,
+  cursor: Vec2,
   widgets: Widgets
 ) => {
-  const movedWidget = move(widget, cursorPosition)
+  const movedWidget = move(widget, cursor)
   const movedRangeWidgets = widgetsBetween(
     widgets,
     movedWidget.pos,
     movedWidget.size
   ).filter(ele => ele.uuid !== widget.uuid)
 
-  return movedRangeWidgets.length === 0 && isInGridSize(movedWidget)
+  if (movedRangeWidgets.length === 0 && isInGridSize(movedWidget)) {
+    widget.pos = plus(widget.pos, cursor)
+    return widgets
+  } else return null
 }

--- a/src/components/users/GridTools.ts
+++ b/src/components/users/GridTools.ts
@@ -71,41 +71,55 @@ const isInGridSize = (widget: Widget) => {
 
 /** 위젯을 밀 수 있는 지 확인하는 함수 [주기능]*/
 export const isPushable = (widget: Widget, cursor: Pos, widgets: Widgets) => {
-  const widgetCopy: Widgets = Array.from(widgets) // 위젯들 밀면서 확인할 widgets의 사본
-  const movedRange = makeMoveCoordinates(widget, cursor) //widget을 cursor만큼 옮길 시 차지하는 좌표범위
-  const movedPos = plus(widget.pos, cursor) //widget을 cursor만큼 옮길 시의 좌표
-  const movedRangeWidgets = widgetsBetween(widgets, movedPos, widget.size)
+  const copyWidgets: Widgets = JSON.parse(JSON.stringify(widgets))
+  const copyWidget = copyWidgets.find(ele => ele.uuid === widget.uuid)
+  if (!copyWidget) return null
+
+  const movedRange = makeMoveCoordinates(copyWidget, cursor) //widget을 cursor만큼 옮길 시 차지하는 좌표범위
+  const movedPos = plus(copyWidget.pos, cursor) //widget을 cursor만큼 옮길 시의 좌표
+  const movedRangeWidgets = widgetsBetween(
+    copyWidgets,
+    movedPos,
+    copyWidget.size
+  )
   const xList = movedRange.map(ele => ele.x)
   const movedRangeMiddleX = (Math.max(...xList) + Math.min(...xList)) / 2
 
   movedRangeWidgets
-    .filter(ele => ele !== widget)
+    .filter(ele => ele.uuid !== copyWidget.uuid)
     .forEach(ele => {
       if (ele.pos.x < movedRangeMiddleX) {
-        if (isPushableTo(ele, pos(-1, 0), widgetCopy)) {
+        if (isPushableTo(ele, pos(-1, 0), copyWidgets)) {
           ele.pos = plus(ele.pos, pos(-1, 0))
-        } else if (isPushableTo(ele, pos(1, 0), widgetCopy)) {
+        } else if (isPushableTo(ele, pos(1, 0), copyWidgets)) {
           ele.pos = plus(ele.pos, pos(1, 0))
         }
       } else {
-        if (isPushableTo(ele, pos(1, 0), widgetCopy)) {
+        if (isPushableTo(ele, pos(1, 0), copyWidgets)) {
           ele.pos = plus(ele.pos, pos(1, 0))
-        } else if (isPushableTo(ele, pos(-1, 0), widgetCopy)) {
+        } else if (isPushableTo(ele, pos(-1, 0), copyWidgets)) {
           ele.pos = plus(ele.pos, pos(-1, 0))
         }
       }
     })
-
-  return isMovableToEmpty(widget, cursor, widgetCopy)
+  return isMovableToEmpty(copyWidget, cursor, copyWidgets)
 }
 
 /**
  * widget를 vec2 방향으로 이동할 수 있는지 확인하기
  */
 const isPushableTo = (widget: Widget, direction: Vec2, widgets: Widgets) => {
-  const movedWidget = move(widget, direction)
+  const copyWidgets: Widgets = JSON.parse(JSON.stringify(widgets))
+  const copyWidget = copyWidgets.find(ele => ele.uuid === widget.uuid)
+  if (!copyWidget) return null
+
+  const movedWidget = move(copyWidget, direction)
   // coordinateRangeWidgets로 옮길 곳에 어떤 위젯들이 차지하고 있는지 확인하고
-  const movedRange = widgetsBetween(widgets, movedWidget.pos, widget.size)
+  const movedRange = widgetsBetween(
+    copyWidgets,
+    movedWidget.pos,
+    copyWidget.size
+  )
 
   if (!isInGridSize(movedWidget)) {
     return false
@@ -115,7 +129,7 @@ const isPushableTo = (widget: Widget, direction: Vec2, widgets: Widgets) => {
     return true
   } else if (
     movedRange.length === 1 &&
-    movedRange[0].uuid === widget.uuid &&
+    movedRange[0].uuid === copyWidget.uuid &&
     isInGridSize(movedRange[0]) // 리스트에 widget만 있으면 어차피 자기 자신이니 true
   )
     return true
@@ -130,17 +144,23 @@ export const moveItemSwap = (
 ) => {
   //1. cursor를 통해 교환할 위젯을 찾는다. 이동하려는 좌표에 위치하고, w h 크기가 같아야 함.
   //2. 조건이 맞으면 교환할 위젯을 반환, 실패하면 false
-  const movedPos = plus(widget.pos, cursor)
-  const swapRange = widgetsBetween(widgets, movedPos, widget.size).filter(
-    ele => ele.uuid !== widget.uuid
-  )
-  if (swapRange.length === 1 && pipe(swapRange[0].size, eq(widget.size))) {
-    const swapWidget = widgets.find(ele => ele.uuid === swapRange[0].uuid)
+  const copyWidgets: Widgets = JSON.parse(JSON.stringify(widgets))
+  const copyWidget = copyWidgets.find(ele => ele.uuid === widget.uuid)
+  if (!copyWidget) return null
+
+  const movedPos = plus(copyWidget.pos, cursor)
+  const swapRange = widgetsBetween(
+    copyWidgets,
+    movedPos,
+    copyWidget.size
+  ).filter(ele => ele.uuid !== copyWidget.uuid)
+  if (swapRange.length === 1 && pipe(swapRange[0].size, eq(copyWidget.size))) {
+    const swapWidget = copyWidgets.find(ele => ele.uuid === swapRange[0].uuid)
     if (swapWidget) {
       const swapCoords = swapWidget.pos
-      swapWidget.pos = widget.pos
-      widget.pos = swapCoords
-      return widgets
+      swapWidget.pos = copyWidget.pos
+      copyWidget.pos = swapCoords
+      return copyWidgets
     } else return null
   }
   return null
@@ -151,15 +171,19 @@ export const isMovableToEmpty = (
   cursor: Vec2,
   widgets: Widgets
 ) => {
-  const movedWidget = move(widget, cursor)
+  const copyWidgets: Widgets = JSON.parse(JSON.stringify(widgets))
+  const copyWidget = copyWidgets.find(ele => ele.uuid === widget.uuid)
+  if (!copyWidget) return null
+
+  const movedWidget = move(copyWidget, cursor)
   const movedRangeWidgets = widgetsBetween(
-    widgets,
+    copyWidgets,
     movedWidget.pos,
     movedWidget.size
-  ).filter(ele => ele.uuid !== widget.uuid)
+  ).filter(ele => ele.uuid !== copyWidget.uuid)
 
   if (movedRangeWidgets.length === 0 && isInGridSize(movedWidget)) {
-    widget.pos = plus(widget.pos, cursor)
-    return widgets
+    copyWidget.pos = plus(copyWidget.pos, cursor)
+    return copyWidgets
   } else return null
 }

--- a/src/components/users/GridTools.ts
+++ b/src/components/users/GridTools.ts
@@ -92,15 +92,15 @@ export const isPushable = (widget: Widget, cursor: Pos, widgets: Widgets) => {
     .forEach(ele => {
       if (ele.pos.x < movedRangeMiddleX) {
         if (isPushableTo(ele, pos(-1, 0), copyWidgets)) {
-          ele.pos = plus(ele.pos, pos(-1, 0))
+          return (ele.pos = plus(ele.pos, pos(-1, 0)))
         } else if (isPushableTo(ele, pos(1, 0), copyWidgets)) {
-          ele.pos = plus(ele.pos, pos(1, 0))
+          return (ele.pos = plus(ele.pos, pos(1, 0)))
         }
       } else {
         if (isPushableTo(ele, pos(1, 0), copyWidgets)) {
-          ele.pos = plus(ele.pos, pos(1, 0))
+          return (ele.pos = plus(ele.pos, pos(1, 0)))
         } else if (isPushableTo(ele, pos(-1, 0), copyWidgets)) {
-          ele.pos = plus(ele.pos, pos(-1, 0))
+          return (ele.pos = plus(ele.pos, pos(-1, 0)))
         }
       }
     })
@@ -135,8 +135,9 @@ const isPushableTo = (widget: Widget, direction: Vec2, widgets: Widgets) => {
     movedRange.length === 1 &&
     movedRange[0].uuid === copyWidget.uuid &&
     isInGridSize(movedRange[0]) // 리스트에 widget만 있으면 어차피 자기 자신이니 true
-  )
+  ) {
     return true
+  }
   return false
 }
 

--- a/src/components/users/GridTools.ts
+++ b/src/components/users/GridTools.ts
@@ -74,7 +74,7 @@ export const pushWidget = (widget: Widget, cursor: Pos, widgets: Widgets) => {
   const copyWidgets: Widgets = JSON.parse(JSON.stringify(widgets))
   const copyWidget = copyWidgets.find(ele => ele.uuid === widget.uuid)
   if (!copyWidget) {
-    return null
+    return undefined
   }
 
   const movedRange = makeMoveCoordinates(copyWidget, cursor) //widget을 cursor만큼 옮길 시 차지하는 좌표범위
@@ -114,7 +114,7 @@ const pushWidgetTo = (widget: Widget, direction: Vec2, widgets: Widgets) => {
   const copyWidgets: Widgets = JSON.parse(JSON.stringify(widgets))
   const copyWidget = copyWidgets.find(ele => ele.uuid === widget.uuid)
   if (!copyWidget) {
-    return null
+    return undefined
   }
 
   const movedWidget = move(copyWidget, direction)
@@ -148,7 +148,7 @@ export const swapWidget = (widget: Widget, cursor: Vec2, widgets: Widgets) => {
   const copyWidgets: Widgets = JSON.parse(JSON.stringify(widgets))
   const copyWidget = copyWidgets.find(ele => ele.uuid === widget.uuid)
   if (!copyWidget) {
-    return null
+    return undefined
   }
 
   const movedPos = plus(copyWidget.pos, cursor)
@@ -165,10 +165,10 @@ export const swapWidget = (widget: Widget, cursor: Vec2, widgets: Widgets) => {
       copyWidget.pos = swapCoords
       return copyWidgets
     } else {
-      return null
+      return undefined
     }
   }
-  return null
+  return undefined
 }
 /** 빈 곳으로 위젯을 이동할 지 여부를 반환한다 [완료] [주기능]*/
 export const moveEmptyWidget = (
@@ -179,7 +179,7 @@ export const moveEmptyWidget = (
   const copyWidgets: Widgets = JSON.parse(JSON.stringify(widgets))
   const copyWidget = copyWidgets.find(ele => ele.uuid === widget.uuid)
   if (!copyWidget) {
-    return null
+    return undefined
   }
 
   const movedWidget = move(copyWidget, cursor)
@@ -193,6 +193,6 @@ export const moveEmptyWidget = (
     copyWidget.pos = plus(copyWidget.pos, cursor)
     return copyWidgets
   } else {
-    return null
+    return undefined
   }
 }

--- a/src/components/users/GridTools.ts
+++ b/src/components/users/GridTools.ts
@@ -73,7 +73,9 @@ const isInGridSize = (widget: Widget) => {
 export const isPushable = (widget: Widget, cursor: Pos, widgets: Widgets) => {
   const copyWidgets: Widgets = JSON.parse(JSON.stringify(widgets))
   const copyWidget = copyWidgets.find(ele => ele.uuid === widget.uuid)
-  if (!copyWidget) return null
+  if (!copyWidget) {
+    return null
+  }
 
   const movedRange = makeMoveCoordinates(copyWidget, cursor) //widget을 cursor만큼 옮길 시 차지하는 좌표범위
   const movedPos = plus(copyWidget.pos, cursor) //widget을 cursor만큼 옮길 시의 좌표
@@ -111,7 +113,9 @@ export const isPushable = (widget: Widget, cursor: Pos, widgets: Widgets) => {
 const isPushableTo = (widget: Widget, direction: Vec2, widgets: Widgets) => {
   const copyWidgets: Widgets = JSON.parse(JSON.stringify(widgets))
   const copyWidget = copyWidgets.find(ele => ele.uuid === widget.uuid)
-  if (!copyWidget) return null
+  if (!copyWidget) {
+    return null
+  }
 
   const movedWidget = move(copyWidget, direction)
   // coordinateRangeWidgets로 옮길 곳에 어떤 위젯들이 차지하고 있는지 확인하고
@@ -146,7 +150,9 @@ export const moveItemSwap = (
   //2. 조건이 맞으면 교환할 위젯을 반환, 실패하면 false
   const copyWidgets: Widgets = JSON.parse(JSON.stringify(widgets))
   const copyWidget = copyWidgets.find(ele => ele.uuid === widget.uuid)
-  if (!copyWidget) return null
+  if (!copyWidget) {
+    return null
+  }
 
   const movedPos = plus(copyWidget.pos, cursor)
   const swapRange = widgetsBetween(
@@ -161,7 +167,9 @@ export const moveItemSwap = (
       swapWidget.pos = copyWidget.pos
       copyWidget.pos = swapCoords
       return copyWidgets
-    } else return null
+    } else {
+      return null
+    }
   }
   return null
 }
@@ -173,7 +181,9 @@ export const isMovableToEmpty = (
 ) => {
   const copyWidgets: Widgets = JSON.parse(JSON.stringify(widgets))
   const copyWidget = copyWidgets.find(ele => ele.uuid === widget.uuid)
-  if (!copyWidget) return null
+  if (!copyWidget) {
+    return null
+  }
 
   const movedWidget = move(copyWidget, cursor)
   const movedRangeWidgets = widgetsBetween(
@@ -185,5 +195,7 @@ export const isMovableToEmpty = (
   if (movedRangeWidgets.length === 0 && isInGridSize(movedWidget)) {
     copyWidget.pos = plus(copyWidget.pos, cursor)
     return copyWidgets
-  } else return null
+  } else {
+    return null
+  }
 }

--- a/src/components/users/Users.tsx
+++ b/src/components/users/Users.tsx
@@ -1,4 +1,3 @@
-import { layoutDummy } from 'dummy'
 import { Grid } from './Grid'
 import { Navigation } from './Navigation'
 import { Store } from './Store'

--- a/src/components/users/Users.tsx
+++ b/src/components/users/Users.tsx
@@ -8,7 +8,7 @@ export const Users = () => {
     <div>
       <Navigation />
       <Store />
-      <Grid widgets={layoutDummy} />
+      <Grid />
     </div>
   )
 }

--- a/src/components/users/users.stories.tsx
+++ b/src/components/users/users.stories.tsx
@@ -1,17 +1,14 @@
 import { StoreWidgetType, Widgets } from 'common'
-import { Grid } from './Grid'
+import { Grid as grid } from './Grid'
 import { Navigation as nav } from './Navigation'
 import type { Story } from '@ladle/react'
-import { layoutDummy, storeDummy } from 'dummy'
+import { storeDummy } from 'dummy'
 import { StoreWidget } from './StoreWidget'
 import { Store as store } from './Store'
 
 export const Navigation = nav
 
-export const grid: Story<{ widgets: Widgets }> = ({ widgets }) => (
-  <Grid widgets={widgets} />
-)
-grid.args = { widgets: layoutDummy }
+export const Grid = grid
 
 export const Store = store
 

--- a/src/components/users/users.stories.tsx
+++ b/src/components/users/users.stories.tsx
@@ -1,4 +1,4 @@
-import { StoreWidgetType, Widgets } from 'common'
+import { StoreWidgetType } from 'common'
 import { Grid as grid } from './Grid'
 import { Navigation as nav } from './Navigation'
 import type { Story } from '@ladle/react'

--- a/src/dummy.ts
+++ b/src/dummy.ts
@@ -102,6 +102,48 @@ export const mock: Widgets = [
     data: JSON.parse('{"aa" : "bb"}'),
   },
 ]
+export const mock1: Widgets = [
+  { ...mock[0], pos: pos(1, 1) },
+  mock[1],
+  mock[2],
+  mock[3],
+  { ...mock[4], pos: pos(0, 0) },
+]
+export const mock2: Widgets = [
+  { ...mock[0], pos: pos(2, 2) },
+  mock[1],
+  mock[2],
+  mock[3],
+  mock[4],
+]
+export const mock3: Widgets = [
+  mock[0],
+  { ...mock[1], pos: pos(2, 0) },
+  mock[2],
+  mock[3],
+  mock[4],
+]
+export const mock4: Widgets = [
+  mock[0],
+  mock[1],
+  { ...mock[2], pos: pos(2, 1) },
+  mock[3],
+  mock[4],
+]
+export const mock5: Widgets = [
+  mock[0],
+  mock[1],
+  mock[2],
+  { ...mock[3], pos: pos(3, 0) },
+  mock[4],
+]
+export const mock6: Widgets = [
+  mock[0],
+  mock[1],
+  mock[2],
+  mock[3],
+  { ...mock[4], pos: pos(2, 1) },
+]
 
 export const storeDummy: StoreWidgets = [
   {


### PR DESCRIPTION
- resolves #39 

## 개요

1. 기존에 이동 관련 함수들이 내부에서 이동 할 수 있는 지 판단 후 바깥에서 그를 토대로 이동을 시켰는데, 이젠 함수에서 모든 동작과 이동을 처리한후, 잘 완료된 배열 혹은 null을 반환하면 그것으로 widgets를 교체하는 식으로 리팩토링함.
2. Array.from을 사용한 얕은 복사가 원인이라 JSON.parse와 stringify를 사용하는 식으로 깊은 복사를 함.
3. 깊은 복사로 바꾼 후 재렌더링이 안되는 문제가 있어 UseState를 사용하도록 변경.