### PR TITLE
test: ladle 내에서 로그인 라우팅

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Temp
+vite.config.ts.*
+
 # Logs
 logs
 *.log

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "jotai": "^1.9.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-router-dom": "^6.4.5",
     "socket.io": "^4.5.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -20,10 +20,10 @@
     "@mantine/hooks": "^5.7.1",
     "@mobily/ts-belt": "4.0.0-rc.0",
     "@tabler/icons": "^1.111.0",
+    "@tanstack/react-router": "0.0.1-beta.38",
     "jotai": "^1.9.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^6.4.5",
     "socket.io": "^4.5.3"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,7 @@ specifiers:
   '@mantine/hooks': ^5.7.1
   '@mobily/ts-belt': 4.0.0-rc.0
   '@tabler/icons': ^1.111.0
+  '@tanstack/react-router': 0.0.1-beta.38
   '@types/react': ^18.0.24
   '@types/react-dom': ^18.0.8
   '@vitejs/plugin-react': ^2.2.0
@@ -28,7 +29,6 @@ specifiers:
   jotai: ^1.9.1
   react: ^18.2.0
   react-dom: ^18.2.0
-  react-router-dom: ^6.4.5
   socket.io: ^4.5.3
   typescript: ^4.6.4
   vite: ^3.2.3
@@ -44,10 +44,10 @@ dependencies:
   '@mantine/hooks': 5.8.2_react@18.2.0
   '@mobily/ts-belt': 4.0.0-rc.0
   '@tabler/icons': 1.112.0_biqbaboplfbrettd7655fr4n2y
+  '@tanstack/react-router': 0.0.1-beta.38_biqbaboplfbrettd7655fr4n2y
   jotai: 1.10.0_3lzqd2prgnu7gkxqqdmtvzna5u
   react: 18.2.0
   react-dom: 18.2.0_react@18.2.0
-  react-router-dom: 6.4.5_biqbaboplfbrettd7655fr4n2y
   socket.io: 4.5.4
 
 devDependencies:
@@ -1289,6 +1289,12 @@ packages:
     dependencies:
       regenerator-runtime: 0.13.11
 
+  /@babel/runtime/7.20.6:
+    resolution: {integrity: sha512-Q+8MqP7TiHMWzSfwiJwXCjyf4GYA4Dgw3emg/7xmwsdLJOZUp+nMqcOwOzzYheuM1rhDu8FSj2l0aoMygEuXuA==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      regenerator-runtime: 0.13.11
+
   /@babel/template/7.18.10:
     resolution: {integrity: sha512-TI+rCtooWHr3QJ27kJxfjutghu44DLnasDMwpDqCXVTal9RLp3RSYNh4NdBrRP2cQAoG9A8juOQl6P6oZG4JxA==}
     engines: {node: '>=6.9.0'}
@@ -1777,13 +1783,13 @@ packages:
   /@radix-ui/number/1.0.0:
     resolution: {integrity: sha512-Ofwh/1HX69ZfJRiRBMTy7rgjAzHmwe4kW9C9Y99HTRUcYLUuVT0KESFj15rPjRgKJs20GPq8Bm5aEDJ8DuA3vA==}
     dependencies:
-      '@babel/runtime': 7.20.1
+      '@babel/runtime': 7.20.6
     dev: false
 
   /@radix-ui/primitive/1.0.0:
     resolution: {integrity: sha512-3e7rn8FDMin4CgeL7Z/49smCA3rFYY3Ha2rUQ7HRWFadS5iCRw08ZgVT1LaNTCNqgvrUiyczLflrVrF0SRQtNA==}
     dependencies:
-      '@babel/runtime': 7.20.1
+      '@babel/runtime': 7.20.6
     dev: false
 
   /@radix-ui/react-compose-refs/1.0.0_react@18.2.0:
@@ -1791,7 +1797,7 @@ packages:
     peerDependencies:
       react: ^16.8 || ^17.0 || ^18.0
     dependencies:
-      '@babel/runtime': 7.20.1
+      '@babel/runtime': 7.20.6
       react: 18.2.0
     dev: false
 
@@ -1800,7 +1806,7 @@ packages:
     peerDependencies:
       react: ^16.8 || ^17.0 || ^18.0
     dependencies:
-      '@babel/runtime': 7.20.1
+      '@babel/runtime': 7.20.6
       react: 18.2.0
     dev: false
 
@@ -1809,7 +1815,7 @@ packages:
     peerDependencies:
       react: ^16.8 || ^17.0 || ^18.0
     dependencies:
-      '@babel/runtime': 7.20.1
+      '@babel/runtime': 7.20.6
       react: 18.2.0
     dev: false
 
@@ -1819,7 +1825,7 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0
       react-dom: ^16.8 || ^17.0 || ^18.0
     dependencies:
-      '@babel/runtime': 7.20.1
+      '@babel/runtime': 7.20.6
       '@radix-ui/react-compose-refs': 1.0.0_react@18.2.0
       '@radix-ui/react-use-layout-effect': 1.0.0_react@18.2.0
       react: 18.2.0
@@ -1832,7 +1838,7 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0
       react-dom: ^16.8 || ^17.0 || ^18.0
     dependencies:
-      '@babel/runtime': 7.20.1
+      '@babel/runtime': 7.20.6
       '@radix-ui/react-slot': 1.0.0_react@18.2.0
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
@@ -1863,7 +1869,7 @@ packages:
     peerDependencies:
       react: ^16.8 || ^17.0 || ^18.0
     dependencies:
-      '@babel/runtime': 7.20.1
+      '@babel/runtime': 7.20.6
       '@radix-ui/react-compose-refs': 1.0.0_react@18.2.0
       react: 18.2.0
     dev: false
@@ -1873,7 +1879,7 @@ packages:
     peerDependencies:
       react: ^16.8 || ^17.0 || ^18.0
     dependencies:
-      '@babel/runtime': 7.20.1
+      '@babel/runtime': 7.20.6
       react: 18.2.0
     dev: false
 
@@ -1882,13 +1888,8 @@ packages:
     peerDependencies:
       react: ^16.8 || ^17.0 || ^18.0
     dependencies:
-      '@babel/runtime': 7.20.1
+      '@babel/runtime': 7.20.6
       react: 18.2.0
-    dev: false
-
-  /@remix-run/router/1.0.5:
-    resolution: {integrity: sha512-my0Mycd+jruq/1lQuO5LBB6WTlL/e8DTCYWp44DfMTDcXz8DcTlgF0ISaLsGewt+ctHN+yA8xMq3q/N7uWJPug==}
-    engines: {node: '>=14'}
     dev: false
 
   /@socket.io/component-emitter/3.1.0:
@@ -1908,6 +1909,34 @@ packages:
     dependencies:
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
+    dev: false
+
+  /@tanstack/react-router/0.0.1-beta.38_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-i/pKuHZLwwB3bmP+Ty8bJtGfitrVNaYGbwtXtTw/jqhm6rXN6fd14jT4yW4XcktecSoWE6QK0yTE7viqdaEGuQ==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      react: '>=16'
+      react-dom: '>=16'
+    dependencies:
+      '@babel/runtime': 7.20.6
+      '@tanstack/router-core': 0.0.1-beta.36_biqbaboplfbrettd7655fr4n2y
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
+      use-sync-external-store: 1.2.0_react@18.2.0
+    dev: false
+
+  /@tanstack/router-core/0.0.1-beta.36_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-debjgkz4v1b0BqgEOaaBN9GVPHibB9IdURa8sE62YZ6xCRfmwPkglxwqx9zbOm1qGBG0edJy2FhXuI0meAHHzQ==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      react: '>=16'
+      react-dom: '>=16'
+    dependencies:
+      '@babel/runtime': 7.20.6
+      history: 5.3.0
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
+      tiny-invariant: 1.3.1
     dev: false
 
   /@types/chai-subset/1.3.3:
@@ -2179,7 +2208,7 @@ packages:
     resolution: {integrity: sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==}
     engines: {node: '>=10', npm: '>=6'}
     dependencies:
-      '@babel/runtime': 7.20.1
+      '@babel/runtime': 7.20.6
       cosmiconfig: 7.1.0
       resolve: 1.22.1
     dev: false
@@ -3660,7 +3689,6 @@ packages:
     resolution: {integrity: sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==}
     dependencies:
       '@babel/runtime': 7.20.1
-    dev: true
 
   /hoist-non-react-statics/3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
@@ -4385,29 +4413,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /react-router-dom/6.4.5_biqbaboplfbrettd7655fr4n2y:
-    resolution: {integrity: sha512-a7HsgikBR0wNfroBHcZUCd9+mLRqZS8R5U1Z1mzLWxFXEkUT3vR1XXmSIVoVpxVX8Bar0nQYYYc9Yipq8dWwAA==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      react: '>=16.8'
-      react-dom: '>=16.8'
-    dependencies:
-      '@remix-run/router': 1.0.5
-      react: 18.2.0
-      react-dom: 18.2.0_react@18.2.0
-      react-router: 6.4.5_react@18.2.0
-    dev: false
-
-  /react-router/6.4.5_react@18.2.0:
-    resolution: {integrity: sha512-1RQJ8bM70YEumHIlNUYc6mFfUDoWa5EgPDenK/fq0bxD8DYpQUi/S6Zoft+9DBrh2xmtg92N5HMAJgGWDhKJ5Q==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      react: '>=16.8'
-    dependencies:
-      '@remix-run/router': 1.0.5
-      react: 18.2.0
-    dev: false
-
   /react-textarea-autosize/8.3.4_fan5qbzahqtxlm5dzefqlqx5ia:
     resolution: {integrity: sha512-CdtmP8Dc19xL8/R6sWvtknD/eCXkQr30dtvC4VmGInhRsfF8X/ihXCq6+9l9qbxmKRiq407/7z5fxE7cVWQNgQ==}
     engines: {node: '>=10'}
@@ -4481,7 +4486,7 @@ packages:
   /regenerator-transform/0.15.1:
     resolution: {integrity: sha512-knzmNAcuyxV+gQCufkYcvOqX/qIIfHLv0u5x79kRxuGojfYVky1f15TzZEu2Avte8QGepvUNTnLskf8E6X6Vyg==}
     dependencies:
-      '@babel/runtime': 7.20.1
+      '@babel/runtime': 7.20.6
     dev: true
 
   /regexp-tree/0.1.24:
@@ -4887,6 +4892,10 @@ packages:
       any-promise: 1.3.0
     dev: true
 
+  /tiny-invariant/1.3.1:
+    resolution: {integrity: sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw==}
+    dev: false
+
   /tinybench/2.3.1:
     resolution: {integrity: sha512-hGYWYBMPr7p4g5IarQE7XhlyWveh1EKhy4wUBS1LrHXCKYgvz+4/jCqgmJqZxxldesn05vccrtME2RLLZNW7iA==}
     dev: true
@@ -5086,6 +5095,14 @@ packages:
       '@types/react': 18.0.25
       react: 18.2.0
       use-isomorphic-layout-effect: 1.1.2_fan5qbzahqtxlm5dzefqlqx5ia
+    dev: false
+
+  /use-sync-external-store/1.2.0_react@18.2.0:
+    resolution: {integrity: sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      react: 18.2.0
     dev: false
 
   /utils-merge/1.0.1:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,6 +28,7 @@ specifiers:
   jotai: ^1.9.1
   react: ^18.2.0
   react-dom: ^18.2.0
+  react-router-dom: ^6.4.5
   socket.io: ^4.5.3
   typescript: ^4.6.4
   vite: ^3.2.3
@@ -46,6 +47,7 @@ dependencies:
   jotai: 1.10.0_3lzqd2prgnu7gkxqqdmtvzna5u
   react: 18.2.0
   react-dom: 18.2.0_react@18.2.0
+  react-router-dom: 6.4.5_biqbaboplfbrettd7655fr4n2y
   socket.io: 4.5.4
 
 devDependencies:
@@ -1882,6 +1884,11 @@ packages:
     dependencies:
       '@babel/runtime': 7.20.1
       react: 18.2.0
+    dev: false
+
+  /@remix-run/router/1.0.5:
+    resolution: {integrity: sha512-my0Mycd+jruq/1lQuO5LBB6WTlL/e8DTCYWp44DfMTDcXz8DcTlgF0ISaLsGewt+ctHN+yA8xMq3q/N7uWJPug==}
+    engines: {node: '>=14'}
     dev: false
 
   /@socket.io/component-emitter/3.1.0:
@@ -4377,6 +4384,29 @@ packages:
     resolution: {integrity: sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==}
     engines: {node: '>=0.10.0'}
     dev: true
+
+  /react-router-dom/6.4.5_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-a7HsgikBR0wNfroBHcZUCd9+mLRqZS8R5U1Z1mzLWxFXEkUT3vR1XXmSIVoVpxVX8Bar0nQYYYc9Yipq8dWwAA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      react: '>=16.8'
+      react-dom: '>=16.8'
+    dependencies:
+      '@remix-run/router': 1.0.5
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
+      react-router: 6.4.5_react@18.2.0
+    dev: false
+
+  /react-router/6.4.5_react@18.2.0:
+    resolution: {integrity: sha512-1RQJ8bM70YEumHIlNUYc6mFfUDoWa5EgPDenK/fq0bxD8DYpQUi/S6Zoft+9DBrh2xmtg92N5HMAJgGWDhKJ5Q==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      react: '>=16.8'
+    dependencies:
+      '@remix-run/router': 1.0.5
+      react: 18.2.0
+    dev: false
 
   /react-textarea-autosize/8.3.4_fan5qbzahqtxlm5dzefqlqx5ia:
     resolution: {integrity: sha512-CdtmP8Dc19xL8/R6sWvtknD/eCXkQr30dtvC4VmGInhRsfF8X/ihXCq6+9l9qbxmKRiq407/7z5fxE7cVWQNgQ==}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,0 +1,4 @@
+export * from './common'
+export * from './login'
+export * from './users'
+export * from './widgets'

--- a/src/components/login/Auth.stories.tsx
+++ b/src/components/login/Auth.stories.tsx
@@ -1,41 +1,15 @@
-import { createMemoryRouter, RouterProvider, Link } from 'react-router-dom'
-
-const Foo = () => (
-  <div>
-    root
-    <Link to='/auth/login'>login</Link>
-    <Link to='/auth'>register</Link>
-  </div>
-)
-
-const Register = () => (
-  <div>
-    register
-    <Link to='/'>home</Link>
-    <Link to='/auth/login'>login</Link>
-  </div>
-)
-
-const Login = () => (
-  <div>
-    login
-    <Link to='/'>home</Link>
-    <Link to='/auth'>register</Link>
-  </div>
-)
+import { createMemoryRouter, RouterProvider } from 'react-router-dom'
+import { LoginPanel } from './Login'
+import { RegisterPanel } from './Register'
 
 const routes = [
   {
-    path: '/',
-    element: <Foo />,
-  },
-  {
     path: '/auth',
-    element: <Register />,
+    element: <RegisterPanel />,
   },
   {
     path: '/auth/login',
-    element: <Login />,
+    element: <LoginPanel />,
   },
 ]
 const router = createMemoryRouter(routes, {

--- a/src/components/login/Auth.stories.tsx
+++ b/src/components/login/Auth.stories.tsx
@@ -1,18 +1,67 @@
-import { createMemoryRouter, RouterProvider } from 'react-router-dom'
-import { LoginPanel } from './Login'
-import { RegisterPanel } from './Register'
+// import { createMemoryRouter, RouterProvider } from 'react-router-dom'
+import {
+  RouterProvider,
+  Link,
+  createReactRouter,
+  createRouteConfig,
+  createMemoryHistory,
+} from '@tanstack/react-router'
+import { Button, Paper, Stack, Text } from '@mantine/core'
+import { Logo } from 'components/common'
+import { Login, OAuthLogin } from './Login'
+import { OAuthRegister, Register } from './Register'
 
-const routes = [
-  {
-    path: '/auth',
-    element: <RegisterPanel />,
-  },
-  {
-    path: '/auth/login',
-    element: <LoginPanel />,
-  },
-]
-const router = createMemoryRouter(routes, {
-  initialEntries: ['/auth/login'],
+const rootRoute = createRouteConfig()
+const authRoute = rootRoute.createRoute({ path: '/auth' })
+
+declare module '@tanstack/react-router' {
+  interface RegisterRouter {
+    router: typeof router
+  }
+}
+
+const indexRoute = authRoute.createRoute({
+  path: '/',
+  component: () => (
+    <Paper>
+      <Stack align='center'>
+        <Logo />
+        <Register />
+        <>
+          <Text>이미 계정이 있으신가요?</Text>
+          <Link to='/auth/login'>
+            <Button variant='default'>로그인</Button>
+          </Link>
+        </>
+        <OAuthRegister />
+      </Stack>
+    </Paper>
+  ),
 })
-export const AuthRouter = () => <RouterProvider router={router} />
+
+const aboutRoute = authRoute.createRoute({
+  path: '/login',
+  component: () => (
+    <Paper>
+      <Stack align='center'>
+        <Logo />
+        <Login />
+        <>
+          <Text>아직 계정이 없으신가요?</Text>
+          <Link to='/auth'>
+            <Button variant='default'>회원가입</Button>
+          </Link>
+        </>
+        <OAuthLogin />
+      </Stack>
+    </Paper>
+  ),
+})
+
+const history = createMemoryHistory({ initialEntries: ['/auth'] })
+
+const routeConfig = rootRoute.addChildren([indexRoute, aboutRoute])
+
+const router = createReactRouter({ routeConfig, history })
+
+export const TestRouter = () => <RouterProvider router={router} />

--- a/src/components/login/Auth.stories.tsx
+++ b/src/components/login/Auth.stories.tsx
@@ -1,67 +1,17 @@
-// import { createMemoryRouter, RouterProvider } from 'react-router-dom'
 import {
   RouterProvider,
-  Link,
   createReactRouter,
-  createRouteConfig,
   createMemoryHistory,
 } from '@tanstack/react-router'
-import { Button, Paper, Stack, Text } from '@mantine/core'
-import { Logo } from 'components/common'
-import { Login, OAuthLogin } from './Login'
-import { OAuthRegister, Register } from './Register'
+import { rootRoute, loginRoute, registerRoute } from 'routes'
 
-const rootRoute = createRouteConfig()
-const authRoute = rootRoute.createRoute({ path: '/auth' })
-
+const history = createMemoryHistory({ initialEntries: ['/auth'] })
+const routeConfig = rootRoute.addChildren([registerRoute, loginRoute])
 declare module '@tanstack/react-router' {
   interface RegisterRouter {
     router: typeof router
   }
 }
-
-const indexRoute = authRoute.createRoute({
-  path: '/',
-  component: () => (
-    <Paper>
-      <Stack align='center'>
-        <Logo />
-        <Register />
-        <>
-          <Text>이미 계정이 있으신가요?</Text>
-          <Link to='/auth/login'>
-            <Button variant='default'>로그인</Button>
-          </Link>
-        </>
-        <OAuthRegister />
-      </Stack>
-    </Paper>
-  ),
-})
-
-const aboutRoute = authRoute.createRoute({
-  path: '/login',
-  component: () => (
-    <Paper>
-      <Stack align='center'>
-        <Logo />
-        <Login />
-        <>
-          <Text>아직 계정이 없으신가요?</Text>
-          <Link to='/auth'>
-            <Button variant='default'>회원가입</Button>
-          </Link>
-        </>
-        <OAuthLogin />
-      </Stack>
-    </Paper>
-  ),
-})
-
-const history = createMemoryHistory({ initialEntries: ['/auth'] })
-
-const routeConfig = rootRoute.addChildren([indexRoute, aboutRoute])
-
 const router = createReactRouter({ routeConfig, history })
 
 export const TestRouter = () => <RouterProvider router={router} />

--- a/src/components/login/Auth.stories.tsx
+++ b/src/components/login/Auth.stories.tsx
@@ -1,0 +1,44 @@
+import { createMemoryRouter, RouterProvider, Link } from 'react-router-dom'
+
+const Foo = () => (
+  <div>
+    root
+    <Link to='/auth/login'>login</Link>
+    <Link to='/auth'>register</Link>
+  </div>
+)
+
+const Register = () => (
+  <div>
+    register
+    <Link to='/'>home</Link>
+    <Link to='/auth/login'>login</Link>
+  </div>
+)
+
+const Login = () => (
+  <div>
+    login
+    <Link to='/'>home</Link>
+    <Link to='/auth'>register</Link>
+  </div>
+)
+
+const routes = [
+  {
+    path: '/',
+    element: <Foo />,
+  },
+  {
+    path: '/auth',
+    element: <Register />,
+  },
+  {
+    path: '/auth/login',
+    element: <Login />,
+  },
+]
+const router = createMemoryRouter(routes, {
+  initialEntries: ['/auth/login'],
+})
+export const AuthRouter = () => <RouterProvider router={router} />

--- a/src/components/login/Login.stories.tsx
+++ b/src/components/login/Login.stories.tsx
@@ -23,7 +23,7 @@ export const OAuthLogin = () => (
     <Text>또는</Text>
     <Button variant='default'>구글 이메일로 로그인</Button>
   </>
-)
+) 
 
 export const LoginPanel = () => {
   return (

--- a/src/components/login/Login.tsx
+++ b/src/components/login/Login.tsx
@@ -1,6 +1,4 @@
-import { Link } from 'react-router-dom'
-import { Button, Paper, Stack, Text } from '@mantine/core'
-import { Logo } from 'components/common'
+import { Button, Text } from '@mantine/core'
 import { CredentialInput } from './CredentialInput'
 
 export const Credential = CredentialInput
@@ -19,24 +17,4 @@ export const OAuthLogin = () => (
   </>
 )
 
-export const TryRegister = () => (
-  <>
-    <Text>아직 계정이 없으신가요?</Text>
-    <Button component={Link} to='/auth' variant='default'>
-      회원가입
-    </Button>
-  </>
-)
 
-export const LoginPanel = () => {
-  return (
-    <Paper>
-      <Stack align='center'>
-        <Logo />
-        <Login />
-        <TryRegister />
-        <OAuthLogin />
-      </Stack>
-    </Paper>
-  )
-}

--- a/src/components/login/Login.tsx
+++ b/src/components/login/Login.tsx
@@ -1,3 +1,4 @@
+import { Link } from 'react-router-dom'
 import { Button, Paper, Stack, Text } from '@mantine/core'
 import { Logo } from 'components/common'
 import { CredentialInput } from './CredentialInput'
@@ -11,19 +12,21 @@ export const Login = () => (
   </>
 )
 
-export const TryRegister = () => (
-  <>
-    <Text>아직 계정이 없으신가요?</Text>
-    <Button variant='default'>회원가입</Button>
-  </>
-)
-
 export const OAuthLogin = () => (
   <>
     <Text>또는</Text>
     <Button variant='default'>구글 이메일로 로그인</Button>
   </>
-) 
+)
+
+export const TryRegister = () => (
+  <>
+    <Text>아직 계정이 없으신가요?</Text>
+    <Button component={Link} to='/auth' variant='default'>
+      회원가입
+    </Button>
+  </>
+)
 
 export const LoginPanel = () => {
   return (

--- a/src/components/login/Register.tsx
+++ b/src/components/login/Register.tsx
@@ -1,8 +1,5 @@
-import { Paper, Stack } from '@mantine/core'
-import { Logo } from 'components/common'
 import { Button, Text } from '@mantine/core'
 import { CredentialInput } from './CredentialInput'
-import { Link } from 'react-router-dom'
 
 export const Register = () => {
   return (
@@ -13,32 +10,9 @@ export const Register = () => {
   )
 }
 
-export const TryLogin = () => (
-  <>
-    <Text>이미 계정이 있으신가요?</Text>
-    <Button component={Link} to='/auth/login' variant='default'>
-      로그인
-    </Button>
-  </>
-)
-
-
 export const OAuthRegister = () => (
   <>
     <Text>또는</Text>
     <Button variant='default'>구글 이메일로 회원가입</Button>
   </>
 )
-
-export const RegisterPanel = () => {
-  return (
-    <Paper>
-      <Stack align='center'>
-        <Logo />
-        <Register />
-        <TryLogin />
-        <OAuthRegister />
-      </Stack>
-    </Paper>
-  )
-}

--- a/src/components/login/Register.tsx
+++ b/src/components/login/Register.tsx
@@ -1,6 +1,8 @@
-import { Button, Paper, Stack, Text } from '@mantine/core'
+import { Paper, Stack } from '@mantine/core'
 import { Logo } from 'components/common'
+import { Button, Text } from '@mantine/core'
 import { CredentialInput } from './CredentialInput'
+import { Link } from 'react-router-dom'
 
 export const Register = () => {
   return (
@@ -10,6 +12,16 @@ export const Register = () => {
     </>
   )
 }
+
+export const TryLogin = () => (
+  <>
+    <Text>이미 계정이 있으신가요?</Text>
+    <Button component={Link} to='/auth/login' variant='default'>
+      로그인
+    </Button>
+  </>
+)
+
 
 export const OAuthRegister = () => (
   <>
@@ -24,6 +36,7 @@ export const RegisterPanel = () => {
       <Stack align='center'>
         <Logo />
         <Register />
+        <TryLogin />
         <OAuthRegister />
       </Stack>
     </Paper>

--- a/src/routes/auth/authRoute.ts
+++ b/src/routes/auth/authRoute.ts
@@ -1,0 +1,3 @@
+import { rootRoute } from '../rootRoute'
+
+export const authRoute = rootRoute.createRoute({ path: '/auth' })

--- a/src/routes/auth/index.ts
+++ b/src/routes/auth/index.ts
@@ -1,0 +1,3 @@
+export * from './authRoute'
+export * from './loginRoute'
+export * from './registerRoute'

--- a/src/routes/auth/loginRoute.tsx
+++ b/src/routes/auth/loginRoute.tsx
@@ -1,0 +1,26 @@
+import { Link } from '@tanstack/react-router'
+import { Button, Paper, Stack, Text, Title } from '@mantine/core'
+import { Logo } from 'components/common'
+import { Login, OAuthLogin } from '../../components/login/Login'
+import { authRoute } from 'routes'
+
+/** /auth/login */
+export const loginRoute = authRoute.createRoute({
+  path: '/login',
+  component: () => (
+    <Paper>
+      <Stack align='center'>
+        <Logo />
+        <Title order={2}>로그인</Title>
+        <Login />
+        <>
+          <Text>아직 계정이 없으신가요?</Text>
+          <Link to='/auth'>
+            <Button variant='default'>회원가입</Button>
+          </Link>
+        </>
+        <OAuthLogin />
+      </Stack>
+    </Paper>
+  ),
+})

--- a/src/routes/auth/registerRoute.tsx
+++ b/src/routes/auth/registerRoute.tsx
@@ -1,0 +1,26 @@
+import { Link } from '@tanstack/react-router'
+import { Button, Paper, Stack, Text, Title } from '@mantine/core'
+import { Logo } from 'components/common'
+import { OAuthRegister, Register } from '../../components/login/Register'
+import { authRoute } from 'routes'
+
+/** /auth */
+export const registerRoute = authRoute.createRoute({
+  path: '/',
+  component: () => (
+    <Paper>
+      <Stack align='center'>
+        <Logo />
+        <Title order={2}>회원가입</Title>
+        <Register />
+        <>
+          <Text>이미 계정이 있으신가요?</Text>
+          <Link to='/auth/login'>
+            <Button variant='default'>로그인</Button>
+          </Link>
+        </>
+        <OAuthRegister />
+      </Stack>
+    </Paper>
+  ),
+})

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,0 +1,2 @@
+export * from './auth'
+export * from './rootRoute'

--- a/src/routes/rootRoute.ts
+++ b/src/routes/rootRoute.ts
@@ -1,0 +1,3 @@
+import { createRouteConfig } from '@tanstack/react-router'
+
+export const rootRoute = createRouteConfig()


### PR DESCRIPTION
- fixes Team-Snacks/Snacks#83

## 개요

![image](https://user-images.githubusercontent.com/54838975/206401473-d6d34c66-4e67-4f99-9d3a-82ae70c26c71.png)

URL을 변경하지 않는 [MemoryRouter](https://tanstack.com/router/v1/docs/guide/history-types#memory-routing)를 사용하여 스토리 내에서 라우팅이 가능하게 구현