### PR TITLE
fix: grid 이벤트 버그 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@dnd-kit/core": "^6.0.5",
+    "@dnd-kit/modifiers": "^6.0.1",
     "@dnd-kit/sortable": "^7.0.1",
     "@dnd-kit/utilities": "^3.2.0",
     "@emotion/react": "^11.10.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3,6 +3,7 @@ lockfileVersion: 5.4
 specifiers:
   '@babel/core': '>=7.0.0 <8.0.0'
   '@dnd-kit/core': ^6.0.5
+  '@dnd-kit/modifiers': ^6.0.1
   '@dnd-kit/sortable': ^7.0.1
   '@dnd-kit/utilities': ^3.2.0
   '@emotion/react': ^11.10.5
@@ -39,6 +40,7 @@ specifiers:
 
 dependencies:
   '@dnd-kit/core': 6.0.5_biqbaboplfbrettd7655fr4n2y
+  '@dnd-kit/modifiers': 6.0.1_vvd3dzag27tc7rclyb2whqqnpe
   '@dnd-kit/sortable': 7.0.1_vvd3dzag27tc7rclyb2whqqnpe
   '@dnd-kit/utilities': 3.2.0_react@18.2.0
   '@emotion/react': 11.10.5_cuziicjcvwawlf5iuhzacuhqcy
@@ -1358,6 +1360,18 @@ packages:
       tslib: 2.4.1
     dev: false
 
+  /@dnd-kit/modifiers/6.0.1_vvd3dzag27tc7rclyb2whqqnpe:
+    resolution: {integrity: sha512-rbxcsg3HhzlcMHVHWDuh9LCjpOVAgqbV78wLGI8tziXY3+qcMQ61qVXIvNKQFuhj75dSfD+o+PYZQ/NUk2A23A==}
+    peerDependencies:
+      '@dnd-kit/core': ^6.0.6
+      react: '>=16.8.0'
+    dependencies:
+      '@dnd-kit/core': 6.0.5_biqbaboplfbrettd7655fr4n2y
+      '@dnd-kit/utilities': 3.2.1_react@18.2.0
+      react: 18.2.0
+      tslib: 2.4.1
+    dev: false
+
   /@dnd-kit/sortable/7.0.1_vvd3dzag27tc7rclyb2whqqnpe:
     resolution: {integrity: sha512-n77qAzJQtMMywu25sJzhz3gsHnDOUlEjTtnRl8A87rWIhnu32zuP+7zmFjwGgvqfXmRufqiHOSlH7JPC/tnJ8Q==}
     peerDependencies:
@@ -1372,6 +1386,15 @@ packages:
 
   /@dnd-kit/utilities/3.2.0_react@18.2.0:
     resolution: {integrity: sha512-h65/pn2IPCCIWwdlR2BMLqRkDxpTEONA+HQW3n765HBijLYGyrnTCLa2YQt8VVjjSQD6EfFlTE6aS2Q/b6nb2g==}
+    peerDependencies:
+      react: '>=16.8.0'
+    dependencies:
+      react: 18.2.0
+      tslib: 2.4.1
+    dev: false
+
+  /@dnd-kit/utilities/3.2.1_react@18.2.0:
+    resolution: {integrity: sha512-OOXqISfvBw/1REtkSK2N3Fi2EQiLMlWUlqnOK/UpOISqBZPWpE6TqL+jcPtMOkE8TqYGiURvRdPSI9hltNUjEA==}
     peerDependencies:
       react: '>=16.8.0'
     dependencies:

--- a/src/atoms.tsx
+++ b/src/atoms.tsx
@@ -1,4 +1,5 @@
 import { Credential, TokenResponse, Widgets } from 'common'
+import { layoutDummy } from 'dummy'
 import { atom } from 'jotai'
 import { atomWithStorage } from 'jotai/utils'
 import { pos } from 'vec2'
@@ -8,7 +9,7 @@ export const cursorInWidgetAtom = atom({
   pos: pos(0, 0),
   name: '',
 })
-export const widgetsAtom = atom<Widgets>([])
+export const widgetsAtom = atom<Widgets>(layoutDummy)
 
 export const credentialAtom = atom<Credential>({ email: '', password: '' })
 

--- a/src/components/users/Grid.tsx
+++ b/src/components/users/Grid.tsx
@@ -15,6 +15,7 @@ import { useAtom, useAtomValue } from 'jotai'
 import { cursorInWidgetAtom, headerConfigAtom, widgetsAtom } from 'atoms'
 import axios from 'axios'
 import { Widgets } from 'common'
+import { restrictToWindowEdges } from '@dnd-kit/modifiers'
 
 const tmpStyle: React.CSSProperties = {
   background: '#ffffff',
@@ -152,7 +153,11 @@ export const Grid = () => {
       onDrop={handleDrop}
       onDragOver={cancleDragOver}
     >
-      <DndContext onDragEnd={handleDragEnd} onDragMove={handleDragMove}>
+      <DndContext
+        onDragEnd={handleDragEnd}
+        onDragMove={handleDragMove}
+        modifiers={[restrictToWindowEdges]}
+      >
         <SortableContext
           items={widgets.map(ele => ele.duuid)}
           strategy={rectSwappingStrategy}

--- a/src/components/users/Grid.tsx
+++ b/src/components/users/Grid.tsx
@@ -32,14 +32,14 @@ export const Grid = () => {
   const cursorInWidget = useAtomValue(cursorInWidgetAtom)
   const config = useAtomValue(headerConfigAtom)
 
-  useEffect(() => {
-    axios
-      .get(`${import.meta.env.VITE_SERVER_IP}/users/widgets`, config)
-      .then(res => {
-        setWidgets(res.data)
-      })
-      .catch(console.log)
-  }, [])
+  // useEffect(() => {
+  //   axios
+  //     .get(`${import.meta.env.VITE_SERVER_IP}/users/widgets`, config)
+  //     .then(res => {
+  //       setWidgets(res.data)
+  //     })
+  //     .catch(console.log)
+  // }, [])
 
   const updateWidgetData = (updatedWidgets: Widgets) => {
     setWidgets(updatedWidgets)

--- a/src/components/users/Store.tsx
+++ b/src/components/users/Store.tsx
@@ -18,18 +18,18 @@ export const Store = () => {
     top: '47px',
     zIndex: '2',
   }
-  const config = useAtomValue(headerConfigAtom)
+  // const config = useAtomValue(headerConfigAtom)
 
-  useEffect(() => {
-    axios
-      .get(`${import.meta.env.VITE_SERVER_IP}/widgets`, config)
-      .then(res => {
-        setStoreWidgets(res.data)
-      })
-      .catch(err => {
-        console.log(err)
-      })
-  }, [])
+  // useEffect(() => {
+  //   axios
+  //     .get(`${import.meta.env.VITE_SERVER_IP}/widgets`, config)
+  //     .then(res => {
+  //       setStoreWidgets(res.data)
+  //     })
+  //     .catch(err => {
+  //       console.log(err)
+  //     })
+  // }, [])
 
   return (
     <div>

--- a/src/components/widgets/Ascii/Ascii.tsx
+++ b/src/components/widgets/Ascii/Ascii.tsx
@@ -46,6 +46,7 @@ export const Ascii = () => {
       <Modal
         opened={opened}
         onClose={() => setOpen(false)}
+        onPointerDown={e => e.stopPropagation()}
         centered
         size='60vw'
         withCloseButton={false}
@@ -62,7 +63,10 @@ export const Ascii = () => {
       </Modal>
 
       <Group position='right'>
-        <ActionIcon onClick={() => setOpen(true)}>
+        <ActionIcon
+          onClick={() => setOpen(true)}
+          onPointerDown={e => e.stopPropagation()}
+        >
           <IconTable />
         </ActionIcon>
       </Group>

--- a/src/components/widgets/Memo.tsx
+++ b/src/components/widgets/Memo.tsx
@@ -18,12 +18,16 @@ export const Memo = ({ widget }: WidgetProps) => {
         placeholder='새 노트'
         value={value.title}
         onChange={e => setValue({ ...value, title: e.currentTarget.value })}
+        onPointerDown={e => e.stopPropagation()}
+        onKeyDown={e => e.stopPropagation()}
       />
       <Textarea
         variant='unstyled'
         placeholder='여기에 메모 작성..'
         value={value.content}
         onChange={e => setValue({ ...value, content: e.currentTarget.value })}
+        onPointerDown={e => e.stopPropagation()}
+        onKeyDown={e => e.stopPropagation()}
       />
     </>
   )


### PR DESCRIPTION
- resolves #65

## 개요
- 그리드 내 위젯의 Input에 포커스가 가지 않는 버그, 버튼이 눌려지지 않는 버그 등 수정.
- 현재 postman mock서버의 월간 사용량을 넘어버려 사용할 수 없습니다. 일단 임시로 만들어 둔dummy를 쓰도록 하였습니다.

## 버그 수정 요약
이벤트가 자식에서 발생하는 건 무시되고 드래그가 최우선으로 실행되는데 리스너가 이 역할을 하고 있음
리스너에서 가지고 있는 이벤트 핸들러는 onPointerDown, onKeyDown 두 이벤트를 가지고 있음
자식에서 이 두 이벤트가 상위 전파되는 것을 막아서 해결함(stopPropagation)


gif는 10메가 이상이라 첨부가 안되네요 아래 링크에서 보시길 바랍니다
[gif 링크](https://www.notion.so/usanglee/grid-e822979c83b1413f9b9be8ceeacf7ab3#f9e384a67cc84264ab7cd7cb3f650549)